### PR TITLE
Add liquidjs override and security check script enforcing >=10.25.0

### DIFF
--- a/eleventy/package-lock.json
+++ b/eleventy/package-lock.json
@@ -1531,9 +1531,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.17.0.tgz",
-      "integrity": "sha512-M4MC5/nencttIJHirl5jFTkl7Yu+grIDLn3Qgl7BPAD3BsbTCQknDxlG5VXWRwslWIjk8lSZZjVq9LioILDk1Q==",
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.0.tgz",
+      "integrity": "sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -1543,7 +1543,7 @@
         "liquidjs": "bin/liquid.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "opencollective",

--- a/eleventy/package.json
+++ b/eleventy/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "npx eleventy --serve",
-    "build": "npx eleventy"
+    "build": "npx eleventy",
+    "test:security": "node scripts/check-liquidjs-version.js"
   },
   "keywords": [
     "tooltip",
@@ -22,5 +23,8 @@
   },
   "devDependencies": {
     "pagefind": "^1.1.1"
+  },
+  "overrides": {
+    "liquidjs": "^10.25.0"
   }
 }

--- a/eleventy/scripts/check-liquidjs-version.js
+++ b/eleventy/scripts/check-liquidjs-version.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const pkg = require('../node_modules/liquidjs/package.json');
+const version = pkg.version;
+const min = process.env.MIN_LIQUIDJS_VERSION || '10.25.0';
+
+function parse(v) {
+  return v.split('.').map((n) => Number(n));
+}
+
+function gte(a, b) {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const av = a[i] || 0;
+    const bv = b[i] || 0;
+    if (av > bv) return true;
+    if (av < bv) return false;
+  }
+  return true;
+}
+
+if (!gte(parse(version), parse(min))) {
+  console.error(`liquidjs ${version} is below minimum safe version ${min}`);
+  process.exit(1);
+}
+
+console.log(`liquidjs ${version} satisfies minimum ${min}`);


### PR DESCRIPTION
### Motivation
- Ensure the project uses a minimum safe `liquidjs` release by pinning and checking the installed version to avoid incompatible or insecure older releases.
- Update the lockfile to align with the enforced version and document a reproducible check for CI or local validation.

### Description
- Added `scripts/check-liquidjs-version.js`, a small Node script that parses the installed `liquidjs` version and fails if it is below `10.25.0`.
- Added a `test:security` npm script that runs the version check with `node scripts/check-liquidjs-version.js`.
- Added an `overrides` entry for `liquidjs` set to `^10.25.0` in `eleventy/package.json` and updated `eleventy/package-lock.json` to reflect `liquidjs@10.25.0` (which also updates the `node` engine requirement to `>=16`).
- Minor `package.json` script formatting adjusted (`build` script trailing comma) to accommodate the new script and override entries.

### Testing
- No automated tests were executed as part of this change; the repository now provides `npm run test:security` to perform the new version check in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af75e97280832db08e98c03acaed1e)